### PR TITLE
Mark server tests as @DirtiesContext

### DIFF
--- a/src/test/java/health/matchbox/server/IgValidateR4Test.java
+++ b/src/test/java/health/matchbox/server/IgValidateR4Test.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.yaml.snakeyaml.Yaml;
@@ -56,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ContextConfiguration(classes = {Application.class})
 @ActiveProfiles("validate-r4")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DirtiesContext
 public class IgValidateR4Test {
 
 	private static final String TARGET_SERVER = "http://localhost:8082/matchboxv3/fhir";

--- a/src/test/java/health/matchbox/server/IgValidateRawProfileTest.java
+++ b/src/test/java/health/matchbox/server/IgValidateRawProfileTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -36,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ContextConfiguration(classes = {Application.class})
 @ActiveProfiles("validate-raw-profile")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DirtiesContext
 public class IgValidateRawProfileTest {
 
 


### PR DESCRIPTION
Fixes #10. This forces Spring to close Hibernate's instance between tests, releasing locks.